### PR TITLE
Switch to Alpine builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,22 @@
-FROM circleci/clojure:lein-2.9.5-node-browsers
+FROM adoptopenjdk/openjdk11:alpine
 
-MAINTAINER Cam Saul <cam@metabase.com>
+ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
-# Install Clojure CLI
-RUN curl -O https://download.clojure.org/install/linux-install-1.10.3.814.sh && \
-        chmod +x linux-install-1.10.3.814.sh && \
-        sudo ./linux-install-1.10.3.814.sh
+# coreutils:    needed for the basic tools
+# ttf-dejavu:   needed for POI
+# fontconfig:   needed for POI
+# bash:         various shell scripts
+# yarn:         frontend building
+# nodejs:       frontend building
+# git:          ./bin/version
+# curl:         needed by script that installs Clojure CLI & Lein
+
+RUN apk add --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl && \
+    curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
+    chmod +x /usr/local/bin/lein && \
+    /usr/local/bin/lein upgrade && \
+    curl https://download.clojure.org/install/linux-install-1.10.3.814.sh -o /tmp/linux-install-1.10.3.814.sh && \
+    chmod +x /tmp/linux-install-1.10.3.814.sh && \
+    sh /tmp/linux-install-1.10.3.814.sh
 
 CMD ["/bin/sh"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 AdoptOpenJDK11:apine + Lein 2.9.5 + Clojure CLI
 
-# coreutils:    needed for the basic tools
-# ttf-dejavu:   needed for POI
-# fontconfig:   needed for POI
-# bash:         various shell scripts
-# yarn:         frontend building
-# nodejs:       frontend building
-# git:          ./bin/version
-# curl:         needed by script that installs Clojure CLI & Lein
+- coreutils:    needed for the basic tools
+- ttf-dejavu:   needed for POI
+- fontconfig:   needed for POI
+- bash:         various shell scripts
+- yarn:         frontend building
+- nodejs:       frontend building
+- git:          ./bin/version
+- curl:         needed by script that installs Clojure CLI & Lein

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 [`metabase/ci`](https://hub.docker.com/repository/docker/metabase/ci)
 [![](https://images.microbadger.com/badges/version/metabase/ci.svg)](https://microbadger.com/images/metabase/ci)
 
-Docker image with some extra stuff installed for use in Metabase CI.
+AdoptOpenJDK11:apine + Lein 2.9.5 + Clojure CLI
 
-This is the default CircleCI Lein + Node (includes Node.js) + browsers (includes Chrome, Firefox, OpenJDK v11, and Geckodriver) Docker image with the following extras installed:
-
-- Clojure CLI
-
-# Building
-
-Should build and push to Dockerhub automatically with each commit
+# coreutils:    needed for the basic tools
+# ttf-dejavu:   needed for POI
+# fontconfig:   needed for POI
+# bash:         various shell scripts
+# yarn:         frontend building
+# nodejs:       frontend building
+# git:          ./bin/version
+# curl:         needed by script that installs Clojure CLI & Lein


### PR DESCRIPTION
A single image for building and testing to guarantee that we are being consistent with the images (libraries) that we use for dev and even our releases.

"one image to rule them all"