### PR TITLE
Create branch for Docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 # git:          ./bin/version
 # curl:         needed by script that installs Clojure CLI & Lein
 
-RUN apk add --update-cache --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl && \
+RUN apk upgrade && apk add --update-cache --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl && \
     curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
     chmod +x /usr/local/bin/lein && \
     /usr/local/bin/lein upgrade && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 # git:          ./bin/version
 # curl:         needed by script that installs Clojure CLI & Lein
 
-RUN apk add --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl && \
+RUN apk add --update-cache --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl && \
     curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
     chmod +x /usr/local/bin/lein && \
     /usr/local/bin/lein upgrade && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 ### DockerHub
 [`metabase/ci`](https://hub.docker.com/repository/docker/metabase/ci)
-[![](https://images.microbadger.com/badges/version/metabase/ci.svg)](https://microbadger.com/images/metabase/ci)
 
 AdoptOpenJDK11:apine + Lein 2.9.5 + Clojure CLI
 


### PR DESCRIPTION
This branch was created just for triggering a new Dockerhub build with the branch name tag, so we pin down the container tag for reproducibility