### PR TITLE
Add openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 # git:          ./bin/version
 # curl:         needed by script that installs Clojure CLI & Lein
 
-RUN apk add --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl && \
+RUN apk add --no-cache coreutils ttf-dejavu fontconfig bash yarn nodejs git curl openssl && \
     curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/local/bin/lein && \
     chmod +x /usr/local/bin/lein && \
     /usr/local/bin/lein upgrade && \

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ AdoptOpenJDK11:apine + Lein 2.9.5 + Clojure CLI
 - nodejs:       frontend building
 - git:          ./bin/version
 - curl:         needed by script that installs Clojure CLI & Lein
+- openssl:      needed to capture SSL certificates during CI setup process


### PR DESCRIPTION
Adding openssl to the base image, since it's needed to capture SSL certificates for Presto (and possibly other SSL related stuff in the future).